### PR TITLE
Issue 22 fixes

### DIFF
--- a/issue-022.md
+++ b/issue-022.md
@@ -24,6 +24,8 @@ This proposal requests $32,000 for conducting 4 events in the Commonwealth of In
 
 The proposal requests 70% of the budget to be paid up front so that it can be used to pay for expenses in advance, with the remaining 30% to be paid when the work has been completed. This degree of up front payment was highlighted as problematic by all of the early comments. @DZ has worked with CryptoDealers for the last year and [expresses](https://proposals.decred.org/proposals/fdd68c87961549750adf29e178128210cb310294080211cf6a35792aa1bb7f63/comments/4) support for the proposal generally but also some concerns about the details.
 
+Before going to Politeia, a pre-proposal was posted [on Reddit](https://www.reddit.com/r/decred/comments/cutc16/decred_events_meetups_in_the_cis_in_20192020/) for feedback.
+
 ## MM Part 3: There Will Be Market Making
 
 i2 Trading won the competition to become Decred's designated market maker, with approval of 68% vs 49% for Tantra Labs and 47% for Grapefruit Trading.
@@ -56,7 +58,7 @@ Published Aug 31 by betterfuture | last updated Sep 1 | 15 comments (+10)
 
 The Market Maker proposals prompted much discussion about how to handle this kind of RFP process in future. The importance of clear terms and a timeline for the RFP proposal was highlighted by Tantra's late entry.
 
-The plan for Politeia is to develop a new RFP type proposal which candidate proposals can link to, voting and determining the options/outcome will be controlled through these RFP proposals. Before opening an RFP proposal, an ordinary proposal asking "should we have this RFP" would be submitted and approved - the 2 "RFP proposals" Politeia has seen thus far are of this type. The main point of discussion about the new RFP type proposals is around whether these should be conducted as multiple-choice proposals (where voters can vote for 1-of-N options and one with the most votes wins) or as parallel proposals where tickets can vote yes/no on each proposal and the winner is the one with the highest yes less no votes aggregate score (as the MM RFP is being conducted). Parallel voting on competing proposals seems to be the priority, with multiple-choice voting likely to come later and be used for a different purpose (more like polling). The prospect of ranked choice voting for this kind of decision was also discussed and has support in principle, but it would be a more significant engineering effort as it would be a major departure from how things currently work.
+The [plan](https://github.com/decred/politeia/issues/966) for Politeia is to develop a new RFP type proposal which candidate proposals can link to. Voting and determining the options/outcome will be controlled through these RFP proposals. Before opening an RFP proposal, an ordinary proposal asking "should we have this RFP" would be submitted and approved - the 2 proposals that we have called "RFP" previously (DEX and MM) are of this type. The main point of discussion about the new RFP type proposals is around whether these should be conducted as multiple-choice proposals (where voters can vote for 1-of-N options and one with the most votes wins) or as parallel proposals where tickets can vote yes/no on each proposal and the winner is the one with the highest yes less no votes aggregate score (as the MM RFP is being conducted). Parallel voting on competing proposals seems to be the priority, with multiple-choice voting likely to come later and be used for a different purpose (more like polling). The prospect of ranked choice voting for this kind of decision was also discussed and has support in principle, but it would be a more significant engineering effort as it would be a major departure from how things currently work.
 
 From Sep 1 until Sep 12 there were:
 
@@ -69,7 +71,7 @@ From Sep 1 until Sep 12 there were:
 
 Snapshot for this issue based on this [commit](https://github.com/decred-proposals/mainnet/commit/b835572d66b8b5acd6f5321d9d22e1ae651c5ec0).
 
-Content for this edition was authored by @richardred
+Content for this edition was authored by @richardred with fixes by @bee.
 
 Image credit: @30000fps.
 

--- a/issue-022.md
+++ b/issue-022.md
@@ -1,4 +1,4 @@
-# Politeia Digest #22 - Sep1 - Sep 12
+# Politeia Digest #22 - Sep 1-12 2019
 
 ![Image credit: @30000fps](img/issue022/022-title.png)
 
@@ -8,62 +8,62 @@
 
 **[Research & Publication of On-Chain DCRUSD & DCRBTC Indicators](https://proposals.decred.org/proposals/f0d1bd7447182328b44c691de88cb660b63df17f1f3a94990af19acea57c09bb)**
 
-Published Sep  6 by permabullnino last updated Sep  7 - 21 comments ()
+Published Sep 6 by permabullnino | last updated Sep 7 | 21 comments ()
 
-This proposal requests $16,500 for further research and publications on @permabullnino's Hyperactive HODLer’s Price (HHP) metric. The proposal originally requested $24,000 and specified a breakdown where $3,000 would be related to previously published work and the remainder would be for new publications. 
+This proposal requests $16,500 for further research and publications on @permabullnino's Hyperactive HODLer's Price (HHP) metric. The proposal originally requested $24,000 and specified a breakdown where $3,000 would be related to previously published work and the remainder would be for new publications.
 
-@permabullnino is known to the community for his [previous work](https://medium.com/@permabullnino) on this subject. The proposal provides a list of topics which will be covered. Most of the high scoring comments on this proposal are positive, with a number of well known community members expressing support for the proposal. 
+@permabullnino is known to the community for his [previous work](https://medium.com/@permabullnino) on this subject. The proposal provides a list of topics which will be covered. Most of the high scoring comments on this proposal are positive, with a number of well known community members expressing support for the proposal.
 
-Many of the early comments concerned the request for payment for previously completed work. Most comments which address this see it as being in line with how Decred operates, with payments for work already completed being low risk for the Treasury as the output is already known. @permabullnino removed the differentiation between past and future work when he edited the proposal to decrease the requested amount, but in a comment suggested that around $3K - $3.5K would be related to previous work. In response to questions @permabullnino has also [clarified](https://proposals.decred.org/proposals/f0d1bd7447182328b44c691de88cb660b63df17f1f3a94990af19acea57c09bb/comments/19) that there would be 4 - 6 new articles produced, of similar style and depth to their previous work.
+Many of the early comments concerned the request for payment for previously completed work. Most comments which address this see it as being in line with how Decred operates, with payments for work already completed being low risk for the Treasury as the output is already known. @permabullnino removed the differentiation between past and future work when he edited the proposal to decrease the requested amount, but in a comment suggested that around $3K - $3.5K would be related to previous work. In response to questions @permabullnino has also [clarified](https://proposals.decred.org/proposals/f0d1bd7447182328b44c691de88cb660b63df17f1f3a94990af19acea57c09bb/comments/19) that there would be 4-6 new articles produced, of similar style and depth to their previous work.
 
 **[DECRED Events & Meetups in the CIS in 2019-2020](https://proposals.decred.org/proposals/fdd68c87961549750adf29e178128210cb310294080211cf6a35792aa1bb7f63)**
 
-Published Sep 10 by bogdan_rud last updated Sep 10 - 5 comments ()
+Published Sep 10 by bogdan\_rud | last updated Sep 10 | 5 comments ()
 
-This proposal requests $32,000 for conducting 4 events in the Commonwealth of Independent States (CIS), 2 in Russia, 1 in Ukraine and 1 in Georgia. The events would be designed for around 100 attendees each and be broadcast live on YouTube. A further 20 videos about Decred would be produced and uploaded to the CryptoDealers Youtube Channel. The proposal targets a figure of 800 - 1,200 new Russian speaking Decred users who install a wallet after the events and videos.
+This proposal requests $32,000 for conducting 4 events in the Commonwealth of Independent States (CIS), 2 in Russia, 1 in Ukraine and 1 in Georgia. The events would be designed for around 100 attendees each and be broadcast live on YouTube. A further 20 videos about Decred would be produced and uploaded to the CryptoDealers YouTube channel. The proposal targets a figure of 800-1,200 new Russian speaking Decred users who install a wallet after the events and videos.
 
-The proposal requests 70% of the budget to be paid up front so that it can be used to pay for expenses in advance, with the remaining 30% to be paid when the work has been completed.  This degree of up front payment was highlighted as problematic by all of the early comments. @DZ has worked with CryptoDealers for the last year and [expresses](https://proposals.decred.org/proposals/fdd68c87961549750adf29e178128210cb310294080211cf6a35792aa1bb7f63/comments/4) support for the proposal generally but also some concerns about the details. 
+The proposal requests 70% of the budget to be paid up front so that it can be used to pay for expenses in advance, with the remaining 30% to be paid when the work has been completed. This degree of up front payment was highlighted as problematic by all of the early comments. @DZ has worked with CryptoDealers for the last year and [expresses](https://proposals.decred.org/proposals/fdd68c87961549750adf29e178128210cb310294080211cf6a35792aa1bb7f63/comments/4) support for the proposal generally but also some concerns about the details.
 
-##  MM Part 3: There Will Be Market Making
+## MM Part 3: There Will Be Market Making
 
-i2 Trading won the competition to become Decred's designated market maker, with approval of 68% vs 49% for Tantra Labs and 47% for Grapefruit Trading. 
+i2 Trading won the competition to become Decred's designated market maker, with approval of 68% vs 49% for Tantra Labs and 47% for Grapefruit Trading.
 
-**Approved: [i2 Trading: DCR Market Making](https://proposals.decred.org/proposals/2eb7ddb29f151691ba14ac8c54d53f6692c1f5e8fe06244edf7d3c33fb440bd9) - 55 comments (+0)**
+**Approved: [i2 Trading: DCR Market Making](https://proposals.decred.org/proposals/2eb7ddb29f151691ba14ac8c54d53f6692c1f5e8fe06244edf7d3c33fb440bd9)** - 55 comments (+0)
 
-11,401 Yes votes, 5,280 No votes (68.3% Yes) - voter participation of 40.9%, support from 28% of tickets.
+11,401 Yes votes, 5,280 No votes (68.3% Yes), voter participation of 40.9%, support from 28% of tickets.
 
-**Rejected: [Tantra Labs - Market Making Proposal](https://proposals.decred.org/proposals/82ce113827140caaaf8b5779ab30402d3ed39f1911fdd2e8fa64cf0dc9e09ecb) - 50 comments (+17)**
+**Rejected: [Tantra Labs - Market Making Proposal](https://proposals.decred.org/proposals/82ce113827140caaaf8b5779ab30402d3ed39f1911fdd2e8fa64cf0dc9e09ecb)** - 50 comments (+17)
 
-7,190 Yes votes, 7,456 No votes (49.1% Yes) - voter participation of 35.9%, support from 18% of tickets.
+7,190 Yes votes, 7,456 No votes (49.1% Yes), voter participation of 35.9%, support from 18% of tickets.
 
-**Rejected: [Grapefruit Trading Market Making proposal](https://proposals.decred.org/proposals/4becbe00bd5ae93312426a8cf5eeef78050f5b8b8430b45f3ea54ca89213f82b) - 41 comments (+1)**
+**Rejected: [Grapefruit Trading Market Making proposal](https://proposals.decred.org/proposals/4becbe00bd5ae93312426a8cf5eeef78050f5b8b8430b45f3ea54ca89213f82b)** - 41 comments (+1)
 
-6,286 Yes votes, 7,059 No votes (47.1% Yes) - voter participation of 32.7%, support from 15% of tickets.
+6,286 Yes votes, 7,059 No votes (47.1% Yes), voter participation of 32.7%, support from 15% of tickets.
 
-Tantra Labs quickly congratulated i2 Trading in the proposals channel and shared a link to a [post](https://medium.com/@TantraLabs/proof-of-politeia-ac87f52243f4) they had written about their experience of making a proposal. Tantra Labs also stated that they intend to progress with their plan of making DCR markets, and will do so in consultation with i2 Trading. 
+Tantra Labs quickly congratulated i2 Trading in the #proposals channel and shared a link to a [post](https://medium.com/@TantraLabs/proof-of-politeia-ac87f52243f4) they had written about their experience of making a proposal. Tantra Labs also stated that they intend to progress with their plan of making DCR markets, and will do so in consultation with i2 Trading.
 
 Voting remained close until around 5 days in to the voting period, when the i2 proposal started to extend a lead. While voting was ongoing @richardred prepared and updated some [analysis](https://github.com/RichardRed0x/pi-research/blob/master/analysis/voting/market-maker-proposal-voting-interim-analysis.md) of patterns within ticket voting to look at whether tickets were voting on some or all of the proposals, and how. This has been updated to reflect the final votes.
 
-Most of the tickets that voted on at least 1 MM proposal voted on all 3 (69%), 10% voted on 2 proposals and 21% voted on just 1 proposal. It was rare for a ticket to vote Yes on all 3 proposals (1.8%) or No on all 3 proposals (2.9%). 
+Most of the tickets that voted on at least 1 MM proposal voted on all 3 (69%), 10% voted on 2 proposals and 21% voted on just 1 proposal. It was rare for a ticket to vote Yes on all 3 proposals (1.8%) or No on all 3 proposals (2.9%).
 
 ## Proposals under discussion
 
 **[Incrementalist Proposal as Small Step to Solving Decred's Liquidity Problem](https://proposals.decred.org/proposals/c9604f7879e4b2cd4f2582d238a7ccea210005c63481bec1ddae44ff93e1340f)**
 
-Published Aug 31 by betterfuture last updated Sep  1 - 15 comments (+10)
+Published Aug 31 by betterfuture | last updated Sep 1 | 15 comments (+10)
 
 ## Other News
 
-The Market Maker proposals prompted much discussion about how to handle this kind of RFP process in future. The importance of clear terms and a timeline for the RFP proposal was highlighted by Tantra's late entry.  
+The Market Maker proposals prompted much discussion about how to handle this kind of RFP process in future. The importance of clear terms and a timeline for the RFP proposal was highlighted by Tantra's late entry.
 
 The plan for Politeia is to develop a new RFP type proposal which candidate proposals can link to, voting and determining the options/outcome will be controlled through these RFP proposals. Before opening an RFP proposal, an ordinary proposal asking "should we have this RFP" would be submitted and approved - the 2 "RFP proposals" Politeia has seen thus far are of this type. The main point of discussion about the new RFP type proposals is around whether these should be conducted as multiple-choice proposals (where voters can vote for 1-of-N options and one with the most votes wins) or as parallel proposals where tickets can vote yes/no on each proposal and the winner is the one with the highest yes less no votes aggregate score (as the MM RFP is being conducted). Parallel voting on competing proposals seems to be the priority, with multiple-choice voting likely to come later and be used for a different purpose (more like polling). The prospect of ranked choice voting for this kind of decision was also discussed and has support in principle, but it would be a more significant engineering effort as it would be a major departure from how things currently work.
 
-From Sep  1 until Sep 12 there were:
+From Sep 1 until Sep 12 there were:
 
 * 2 new proposals submitted, 3 proposals started voting, 3 proposals finished voting.
 * Proposals that have finished voting have an average (mean) turnout of 36.5%, with a total of 44,672 ticket votes being cast.
 * 53 comments on Politeia proposals from 20 different users.
-*  135  up/down votes on comments from  20  different voting users.
+* 135 up/down votes on comments from 20 different voting users.
 
 ## About this issue
 

--- a/issue-022.md
+++ b/issue-022.md
@@ -7,6 +7,7 @@
 ## New proposals
 
 **[Research & Publication of On-Chain DCRUSD & DCRBTC Indicators](https://proposals.decred.org/proposals/f0d1bd7447182328b44c691de88cb660b63df17f1f3a94990af19acea57c09bb)**
+
 Published Sep  6 by permabullnino last updated Sep  7 - 21 comments ()
 
 This proposal requests $16,500 for further research and publications on @permabullnino's Hyperactive HODLer’s Price (HHP) metric. The proposal originally requested $24,000 and specified a breakdown where $3,000 would be related to previously published work and the remainder would be for new publications. 
@@ -16,6 +17,7 @@ This proposal requests $16,500 for further research and publications on @permabu
 Many of the early comments concerned the request for payment for previously completed work. Most comments which address this see it as being in line with how Decred operates, with payments for work already completed being low risk for the Treasury as the output is already known. @permabullnino removed the differentiation between past and future work when he edited the proposal to decrease the requested amount, but in a comment suggested that around $3K - $3.5K would be related to previous work. In response to questions @permabullnino has also [clarified](https://proposals.decred.org/proposals/f0d1bd7447182328b44c691de88cb660b63df17f1f3a94990af19acea57c09bb/comments/19) that there would be 4 - 6 new articles produced, of similar style and depth to their previous work.
 
 **[DECRED Events & Meetups in the CIS in 2019-2020](https://proposals.decred.org/proposals/fdd68c87961549750adf29e178128210cb310294080211cf6a35792aa1bb7f63)**
+
 Published Sep 10 by bogdan_rud last updated Sep 10 - 5 comments ()
 
 This proposal requests $32,000 for conducting 4 events in the Commonwealth of Independent States (CIS), 2 in Russia, 1 in Ukraine and 1 in Georgia. The events would be designed for around 100 attendees each and be broadcast live on YouTube. A further 20 videos about Decred would be produced and uploaded to the CryptoDealers Youtube Channel. The proposal targets a figure of 800 - 1,200 new Russian speaking Decred users who install a wallet after the events and videos.
@@ -31,9 +33,11 @@ i2 Trading won the competition to become Decred's designated market maker, with 
 11,401 Yes votes, 5,280 No votes (68.3% Yes) - voter participation of 40.9%, support from 28% of tickets.
 
 **Rejected: [Tantra Labs - Market Making Proposal](https://proposals.decred.org/proposals/82ce113827140caaaf8b5779ab30402d3ed39f1911fdd2e8fa64cf0dc9e09ecb) - 50 comments (+17)**
+
 7,190 Yes votes, 7,456 No votes (49.1% Yes) - voter participation of 35.9%, support from 18% of tickets.
 
 **Rejected: [Grapefruit Trading Market Making proposal](https://proposals.decred.org/proposals/4becbe00bd5ae93312426a8cf5eeef78050f5b8b8430b45f3ea54ca89213f82b) - 41 comments (+1)**
+
 6,286 Yes votes, 7,059 No votes (47.1% Yes) - voter participation of 32.7%, support from 15% of tickets.
 
 Tantra Labs quickly congratulated i2 Trading in the proposals channel and shared a link to a [post](https://medium.com/@TantraLabs/proof-of-politeia-ac87f52243f4) they had written about their experience of making a proposal. Tantra Labs also stated that they intend to progress with their plan of making DCR markets, and will do so in consultation with i2 Trading. 
@@ -45,6 +49,7 @@ Most of the tickets that voted on at least 1 MM proposal voted on all 3 (69%), 1
 ## Proposals under discussion
 
 **[Incrementalist Proposal as Small Step to Solving Decred's Liquidity Problem](https://proposals.decred.org/proposals/c9604f7879e4b2cd4f2582d238a7ccea210005c63481bec1ddae44ff93e1340f)**
+
 Published Aug 31 by betterfuture last updated Sep  1 - 15 comments (+10)
 
 ## Other News
@@ -54,6 +59,7 @@ The Market Maker proposals prompted much discussion about how to handle this kin
 The plan for Politeia is to develop a new RFP type proposal which candidate proposals can link to, voting and determining the options/outcome will be controlled through these RFP proposals. Before opening an RFP proposal, an ordinary proposal asking "should we have this RFP" would be submitted and approved - the 2 "RFP proposals" Politeia has seen thus far are of this type. The main point of discussion about the new RFP type proposals is around whether these should be conducted as multiple-choice proposals (where voters can vote for 1-of-N options and one with the most votes wins) or as parallel proposals where tickets can vote yes/no on each proposal and the winner is the one with the highest yes less no votes aggregate score (as the MM RFP is being conducted). Parallel voting on competing proposals seems to be the priority, with multiple-choice voting likely to come later and be used for a different purpose (more like polling). The prospect of ranked choice voting for this kind of decision was also discussed and has support in principle, but it would be a more significant engineering effort as it would be a major departure from how things currently work.
 
 From Sep  1 until Sep 12 there were:
+
 * 2 new proposals submitted, 3 proposals started voting, 3 proposals finished voting.
 * Proposals that have finished voting have an average (mean) turnout of 36.5%, with a total of 44,672 ticket votes being cast.
 * 53 comments on Politeia proposals from 20 different users.


### PR DESCRIPTION
- formatting of the h1 title consistent with previous issues
- added missing line breaks to please Markdown
- added pipes to the standard proposal status lines
- removed extra spaces from number ranges so that Medium will render them with endash properly

Git/GitHub showed crazy diffs so I split it into 3 commits that are very small individually.